### PR TITLE
Handle GetRepliesRequest errors

### DIFF
--- a/app/userbot.py
+++ b/app/userbot.py
@@ -4,7 +4,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from telethon.tl.types import Message
 from telethon import events
-from telethon.tl.functions.channels import GetFullChannelRequest, GetRepliesRequest
+from telethon.tl.functions.channels import GetFullChannelRequest
+from telethon.tl.functions.messages import GetRepliesRequest
 from telethon.errors import MsgIdInvalidError
 from datetime import datetime
 from app.api import hashtags_api


### PR DESCRIPTION
## Summary
- pre-resolve `WATCH_CHANNEL` entity before loops
- use resolved entity for channel requests
- gracefully handle `MsgIdInvalidError` when fetching replies

## Testing
- `python -m py_compile app/userbot.py`
- `python -m py_compile app/utils/extract_hashtags.py`
- `python -m py_compile app/telegram_client.py app/api/hashtags_api.py app/api/contest.py app/cerber.py`


------
https://chatgpt.com/codex/tasks/task_e_684d31127b5c8332bd75da502dba4636